### PR TITLE
Fix Warning during formating/macro-expansion

### DIFF
--- a/src/hdTri/renderDelegate.cpp
+++ b/src/hdTri/renderDelegate.cpp
@@ -132,7 +132,7 @@ HdTriRenderDelegate::CreateFallbackSprim(const TfToken& typeId)
         return new HdCamera(SdfPath::EmptyPath());
     } else {
         TF_CODING_ERROR("Unknown Fallback Sprim type=%s id=%s",
-                        typeId.GetText());
+                        typeId.GetText(), typeId.GetText());
     }
     return nullptr;
 }


### PR DESCRIPTION
**Issue**
During compilation, there is a warning:

`[...]/src/hdTri/renderDelegate.cpp:134:61: warning: more '%' conversions than data arguments [-Wformat-insufficient-args]
        TF_CODING_ERROR("Unknown Fallback Sprim type=%s id=%s",
                                                           ~^
[...]/include/pxr/base/tf/diagnostic.h:324:42: note: expanded from macro 'TF_CODING_ERROR'
        TF_DIAGNOSTIC_CODING_ERROR_TYPE, __VA_ARGS__)
                                         ^~~~~~~~~~~`

This PR fixes the warning 